### PR TITLE
Add ability to specify LUT file paths via command argument

### DIFF
--- a/DwmLutGUI/DwmLutGUI/MainWindow.xaml.cs
+++ b/DwmLutGUI/DwmLutGUI/MainWindow.xaml.cs
@@ -37,7 +37,7 @@ namespace DwmLutGUI
             var args = Environment.GetCommandLineArgs().ToList();
             args.RemoveAt(0);
 
-            var exitImmediately = args.Contains("-exit");
+            bool exitImmediately = args.Contains("-exit");
 
             if (args.Contains("-apply"))
             {
@@ -222,22 +222,22 @@ namespace DwmLutGUI
 
         private void ArgLutPath(System.Collections.Generic.IList<string> args, string argName, Action<MonitorData, string> callback)
         {
-            var argIndex = args.IndexOf(argName);
+            int argIndex = args.IndexOf(argName);
             if (argIndex == -1)
             {
                 return;
             }
 
-            var argValue = args.ElementAtOrDefault(argIndex + 1);
+            string argValue = args.ElementAtOrDefault(argIndex + 1);
             if (argValue == null)
             {
                 return;
             }
 
             char[] monitorValueSplitter = { ':' };
-            foreach (var monitorIndexToValue in argValue.Split(';'))
+            foreach (string monitorIndexToValue in argValue.Split(';'))
             {
-                var splitted = monitorIndexToValue.Split(monitorValueSplitter, 2);
+                string[] splitted = monitorIndexToValue.Split(monitorValueSplitter, 2);
                 if (int.TryParse(splitted[0], out int monitorIndex))
                 {
                     monitorIndex -= 1;
@@ -247,19 +247,19 @@ namespace DwmLutGUI
                     continue;
                 }
 
-                var monitorObject = _viewModel.Monitors.ElementAtOrDefault(monitorIndex);
+                MonitorData monitorObject = _viewModel.Monitors.ElementAtOrDefault(monitorIndex);
                 if (monitorObject == null)
                 {
                     continue;
                 }
 
-                var pristineValue = splitted.ElementAtOrDefault(1);
+                string pristineValue = splitted.ElementAtOrDefault(1);
                 if (pristineValue == null)
                 {
                     continue;
                 }
 
-                var trimmedValue = pristineValue.Trim();
+                string trimmedValue = pristineValue.Trim();
                 if (trimmedValue != "")
                 {
                     callback(monitorObject, trimmedValue);

--- a/DwmLutGUI/DwmLutGUI/MainWindow.xaml.cs
+++ b/DwmLutGUI/DwmLutGUI/MainWindow.xaml.cs
@@ -228,8 +228,14 @@ namespace DwmLutGUI
                 return;
             }
 
+            var argValue = args.ElementAtOrDefault(argIndex + 1);
+            if (argValue == null)
+            {
+                return;
+            }
+
             char[] monitorValueSplitter = { ':' };
-            foreach (var monitorIndexToValue in args[argIndex + 1].Split(';'))
+            foreach (var monitorIndexToValue in argValue.Split(';'))
             {
                 var splitted = monitorIndexToValue.Split(monitorValueSplitter, 2);
                 if (int.TryParse(splitted[0], out int monitorIndex))
@@ -242,8 +248,19 @@ namespace DwmLutGUI
                 }
 
                 var monitorObject = _viewModel.Monitors.ElementAtOrDefault(monitorIndex);
-                var trimmedValue = splitted[1].Trim();
-                if (monitorObject != null && trimmedValue != "")
+                if (monitorObject == null)
+                {
+                    continue;
+                }
+
+                var pristineValue = splitted.ElementAtOrDefault(1);
+                if (pristineValue == null)
+                {
+                    continue;
+                }
+
+                var trimmedValue = pristineValue.Trim();
+                if (trimmedValue != "")
                 {
                     callback(monitorObject, trimmedValue);
                 }


### PR DESCRIPTION
DwmLut has some useful command arguments right now. However, if user wants to switch between different lut files via command, he has to edit config.xml then run with `-apply`.

This is attempt to fill the void by supporting two extra arguments "-sdr" and "-hdr". Example:
```
DwmLutGUI.exe -sdr "1:C:\luts\1\sdr.lut;2:C:\luts\2\sdr.lut" -hdr "1:C:\luts\1\hdr.lut;2:C:\luts\2\hdr.lut" -apply -exit
```
This example sets monitor 1's SDR lut to "C:\luts\1\sdr.lut", and monitor 2's SDR lut to "C:\luts\2\sdr.lut". Similar to HDR luts.

Also, paths set via this way does not permanently change the content of config.xml. This suits the "temporary" nature of this argument.

What do you think?